### PR TITLE
Fix logic bug in Redirect middleware

### DIFF
--- a/lib/Plack/Middleware/Redirect.pm
+++ b/lib/Plack/Middleware/Redirect.pm
@@ -49,7 +49,7 @@ sub call {
         my $type = ref $to;
 
         if ($type ne 'ARRAY') {
-            my $to = [$to, 301];
+            $to = [$to, 301];
         }
 
         my ($to_path, $status_code) = @$to;

--- a/t/01_basic.t
+++ b/t/01_basic.t
@@ -79,5 +79,19 @@ sub tests {
             status_code => '301',
             body    => "Moved Permanently",
         },
+
+        {   
+            url  => '/old/path.html',
+            location => '/new/path.html',
+            status_code => '301',
+            body    => "Moved Permanently",
+        },
+
+        {   
+            url  => '/2022_12_31',
+            location => '/2022/12/31',
+            status_code => '301',
+            body    => "Moved Permanently",
+        },
     );
 }                        


### PR DESCRIPTION
That 'my' means the assignment isn't going to escape its little 'if' block.

Also added tests to exercise that path. These examples already in the test

    '/old/path.html' => '/new/path.html',
    '/query.html'   => '/query.html?q=y',
    '^/(\d{4})_(\d{2})_(\d{2})$'       => '/$1/$2/$3',

would all fail with this error without this patch.

    'Can't use string ("/new/path.html") as an ARRAY ref while
     "strict refs" in use at lib/Plack/Middleware/Redirect.pm line 56.