### PR TITLE
Remove useless re-regexification

### DIFF
--- a/lib/Plack/Middleware/Redirect.pm
+++ b/lib/Plack/Middleware/Redirect.pm
@@ -44,7 +44,7 @@ sub call {
     for ( my $i = 0; $i < scalar(@$url_patterns); $i += 2 ) {
         my ($from, $to) = _fetch_url_pattern($url_patterns, $i);
 
-        next unless $path =~ m#$from#;
+        next unless $path =~ $from;
         
         my $type = ref $to;
 


### PR DESCRIPTION
prepare_app() is already regexifying that parameter above, via:

    if ($type ne 'Regexp') {
        $url_patterns->[$i] = qr/$from/;
    }

so doing it again in `$path =~ m#$from#` is technically unnecessary, and potentially misleading.